### PR TITLE
Updates for libgps >= 3.20 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ AC_PROG_INSTALL
 AC_PROG_LIBTOOL
 
 PKG_CHECK_MODULES(GPSD, [
-		  libgps >= 3.19
+		  libgps >= 3.20
 ])
 
 AC_SUBST(GPS_LIBS)

--- a/rpm/geoclue-provider-gpsd3.spec
+++ b/rpm/geoclue-provider-gpsd3.spec
@@ -1,12 +1,12 @@
 Name: geoclue-provider-gpsd3
-Version: 0.2
+Version: 0.3
 Release: 1
 Summary: geoclue provider for gpsd daemon
 Group: System/Libraries
 URL: https://github.com/neochapay/geoclue-provider-gpsd3
 License: LGPLv2.1
 Source: %{name}-%{version}.tar.gz
-BuildRequires: pkgconfig(libgps) >= 3.19
+BuildRequires: pkgconfig(libgps) >= 3.20
 BuildRequires: pkgconfig(geoclue) >= 0.12.99
 
 %description

--- a/src/geoclue-gpsd3.c
+++ b/src/geoclue-gpsd3.c
@@ -420,7 +420,7 @@ geoclue_gpsd_update_status (GeoclueGpsd *gpsd)
 		status = GEOCLUE_STATUS_UNAVAILABLE;
 	} else if (gps_raw_data.set & STATUS_SET) {
 		gps_raw_data.set &= ~(STATUS_SET);
-		if (gps_raw_data.fix.mode > 1) {  # 2D or 3D fix
+		if (gps_raw_data.fix.mode > 1) {  /*  2D or 3D fix */
 			status = GEOCLUE_STATUS_AVAILABLE;
 		} else {
 			status = GEOCLUE_STATUS_ACQUIRING;
@@ -471,17 +471,17 @@ gboolean
 gpsd_poll(gpointer data)
 {
 	GeoclueGpsd *self = (GeoclueGpsd*)data;
-        boolean found = false;
+        gboolean found = FALSE;
 	while (gps_waiting(&gps_raw_data, 500)) {
 		if (gps_read(&gps_raw_data, NULL, 0) == -1) {
 			geoclue_gpsd_set_status (self, GEOCLUE_STATUS_ERROR);
 			geoclue_gpsd_stop_gpsd(self);
 			return FALSE;
 		}
-		found = true;
+		found = TRUE;
 	}
 	if (found) {
-        	gpsd_raw_hook(&gps_raw_data, NULL, 0);  # process last proper record
+                gpsd_raw_hook(&gps_raw_data, NULL, 0);  /* process last proper record */
 	}
 	return TRUE;
 }


### PR DESCRIPTION
libgps >= 3.20 uses timespec instead of floats for timestamps. These small changes make to code compile and work (at least for me) again.